### PR TITLE
Fix redundant drawing connection

### DIFF
--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -202,8 +202,8 @@ class Signal1DLine(object):
     @property
     def get_complex(self):
         warnings.warn("The `get_complex` attribute is deprecated and will be"
-              "removed in 2.0, please use `_plot_imag` instead.",
-              VisibleDeprecationWarning)
+                      "removed in 2.0, please use `_plot_imag` instead.",
+                      VisibleDeprecationWarning)
         return self._plot_imag
 
     @property

--- a/hyperspy/drawing/signal1d.py
+++ b/hyperspy/drawing/signal1d.py
@@ -87,10 +87,11 @@ class Signal1DFigure(BlittedFigure):
             line.sf_lines = self.right_ax_lines
             if line.axes_manager is None:
                 line.axes_manager = self.right_axes_manager
-        line.axes_manager.events.indices_changed.connect(line.update, [])
+        line.axes_manager.events.indices_changed.connect(
+            line._auto_update_line, [])
         self.events.closed.connect(
             lambda: line.axes_manager.events.indices_changed.disconnect(
-                line.update), [])
+                line._auto_update_line), [])
         line.axis = self.axis
         # Automatically asign the color if not defined
         if line.color is None:
@@ -154,6 +155,9 @@ class Signal1DLine(object):
         containing valid line properties. In addition it understands
         the keyword `type` that can take the following values:
         {'scatter', 'step', 'line'}
+    auto_update: bool
+        If False, executing ``_auto_update_line`` does not update the
+        line plot.
 
     Methods
     -------
@@ -308,10 +312,17 @@ class Signal1DLine(object):
                                      animated=self.ax.figure.canvas.supports_blit)
         self.ax.figure.canvas.draw_idle()
 
-    def update(self, force_replot=False, ignore_auto_update=False):
+    def _auto_update_line(self, *args, **kwargs):
+        """Updates the line plot only if `auto_update` is `True`.
+
+        This is useful to connect to events that automatically update the line.
+
+        """
+        if self.auto_update:
+            self.update(self, *args, **kwargs)
+
+    def update(self, force_replot=False):
         """Update the current spectrum figure"""
-        if self.auto_update is False and ignore_auto_update is False:
-            return
         if force_replot is True:
             self.close()
             self.plot()

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -57,6 +57,8 @@ _logger = logging.getLogger(__name__)
 
 class DummyComponentsContainer:
     pass
+
+
 components = DummyComponentsContainer()
 components.__dict__.update(components1d.__dict__)
 components.__dict__.update(components2d.__dict__)
@@ -563,7 +565,8 @@ class BaseModel(list):
         if self._model_line is None:
             return
         for component in components:
-            component.events.active_changed.disconnect(self._model_line._auto_update_line)
+            component.events.active_changed.disconnect(
+                self._model_line._auto_update_line)
             for parameter in component.parameters:
                 parameter.events.value_changed.disconnect(
                     self._model_line._auto_update_line)
@@ -585,7 +588,7 @@ class BaseModel(list):
                 for component in [component for component in self if
                                   component.active is True]:
                     self._update_component_line(component)
-            except:
+            except BaseException:
                 self._disconnect_parameters2update_plot(components=self)
 
     @contextmanager

--- a/hyperspy/models/model1d.py
+++ b/hyperspy/models/model1d.py
@@ -687,7 +687,7 @@ class Model1D(BaseModel):
     @staticmethod
     def _connect_component_line(component):
         if hasattr(component, "_model_plot_line"):
-            f = component._model_plot_line.update
+            f = component._model_plot_line._auto_update_line
             component.events.active_changed.connect(f, [])
             for parameter in component.parameters:
                 parameter.events.value_changed.connect(f, [])
@@ -695,7 +695,7 @@ class Model1D(BaseModel):
     @staticmethod
     def _disconnect_component_line(component):
         if hasattr(component, "_model_plot_line"):
-            f = component._model_plot_line.update
+            f = component._model_plot_line._auto_update_line
             component.events.active_changed.disconnect(f)
             for parameter in component.parameters:
                 parameter.events.value_changed.disconnect(f)

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -254,7 +254,7 @@ class Smoothing(t.HasTraits):
                 try:
                     # PySide
                     return np.array(self.line_color.getRgb()) / 255.
-                except:
+                except BaseException:
                     return matplotlib.colors.to_rgb(self.line_color_ipy)
         else:
             return matplotlib.colors.to_rgb(self.line_color_ipy)

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1080,7 +1080,7 @@ class SpikesRemoval(SpanSelectorInSignal1D):
         if self.interpolated_line is None:
             return
         else:
-            self.interpolated_line.update(ignore_auto_update=True)
+            self.interpolated_line.update()
 
     def apply(self):
         if not self.interpolated_line:  # No spike selected


### PR DESCRIPTION
Reverts workaround for (yet!) another bug and fixes it. In particular calling ``line.update`` should always update the line in the figure, regardless of the value of ``auto_update``.
