### PR TITLE
Raise exceptions for functions not working with non linear axis.

### DIFF
--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -348,8 +348,11 @@ class LazySignal(BaseSignal):
                     "The output shape %s does not match  the shape of "
                     "`out` %s" % (new_data.shape, out.data.shape))
         axis2 = s.axes_manager[axis]
-        new_offset = self.axes_manager[axis].offset + (order * axis2.scale / 2)
-        axis2.offset = new_offset
+        if not self.axes_manager[axis].is_linear:
+            axis2.axes_manager[axis].axis = self.axes_manager[axis].axis[:-1]
+        else:
+            new_offset = self.axes_manager[axis].offset + (order * axis2.scale / 2)
+            axis2.offset = new_offset
         s.get_dimensions_from_data()
         if out is None:
             return s

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -408,6 +408,8 @@ class Signal1D(BaseSignal, CommonSignal1D):
         ------
         SignalDimensionError
             If the signal dimension is not 1.
+        NonLinearAxisError
+            If the signal axis is not a linear axis.
         """
         if not np.any(shift_array):
             # Nothing to do, the shift array if filled with zeros
@@ -416,6 +418,9 @@ class Signal1D(BaseSignal, CommonSignal1D):
             show_progressbar = preferences.General.show_progressbar
         self._check_signal_dimension_equals_one()
         axis = self.axes_manager.signal_axes[0]
+        
+        if not axis.is_linear:
+            raise NonLinearAxisError()
 
         # Figure out min/max shifts, and translate to shifts in index as well
         minimum, maximum = np.nanmin(shift_array), np.nanmax(shift_array)

--- a/hyperspy/_signals/signal2d.py
+++ b/hyperspy/_signals/signal2d.py
@@ -594,6 +594,11 @@ class Signal2D(BaseSignal, CommonSignal2D):
         The statistical analysis approach to the translation estimation
         when using `reference`='stat' roughly follows [1]_ . If you use
         it please cite their article.
+        
+        Raises
+        ------
+        NonLinearAxisError
+            If one of the signal axes is not a linear axis.
 
         References
         ----------
@@ -640,6 +645,8 @@ class Signal2D(BaseSignal, CommonSignal2D):
                            shifts[:, 0].max() > 0 else 0)
             xaxis = self.axes_manager.signal_axes[0]
             yaxis = self.axes_manager.signal_axes[1]
+            if (not xaxis.is_linear) or (not yaxis.is_linear):
+                raise NonLinearAxisError()
             padding = []
             for i in range(self.data.ndim):
                 if i == xaxis.index_in_array:

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -31,7 +31,7 @@ from hyperspy.misc.utils import isiterable, ordinal
 from hyperspy.misc.math_tools import isfloat
 from hyperspy.ui_registry import add_gui_method, get_gui
 from hyperspy.defaults_parser import preferences
-from hyperspy.exceptions import NonLinearAccessError
+from hyperspy.exceptions import NonLinearAxisError
 
 
 import warnings
@@ -1357,11 +1357,15 @@ class AxesManager(t.HasTraits):
             first axis is used for all axes. If `False`, convert all axes
             individually.
         %s
+        
+        Note
+        ----
+        Requires a linear axis.
         """
         convert_navigation = convert_signal = True
 
         if not self[axes].is_linear:
-            raise NonLinearAccessError()
+            raise NonLinearAxisError()
         if axes is None:
             axes = self.navigation_axes + self.signal_axes
             convert_navigation = (len(self.navigation_axes) > 0)

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -31,6 +31,7 @@ from hyperspy.misc.utils import isiterable, ordinal
 from hyperspy.misc.math_tools import isfloat
 from hyperspy.ui_registry import add_gui_method, get_gui
 from hyperspy.defaults_parser import preferences
+from hyperspy.exceptions import NonLinearAccessError
 
 
 import warnings
@@ -781,6 +782,7 @@ class FunctionalDataAxis(BaseDataAxis):
         self.__init__(**d, axis=self.axis)
 
     def crop(self, start=None, end=None):
+        raise ValueError('Function still needs to be implemented')
         # TODO
         pass
 
@@ -1358,6 +1360,8 @@ class AxesManager(t.HasTraits):
         """
         convert_navigation = convert_signal = True
 
+        if not self[axes].is_linear:
+            raise NonLinearAccessError()
         if axes is None:
             axes = self.navigation_axes + self.signal_axes
             convert_navigation = (len(self.navigation_axes) > 0)

--- a/hyperspy/exceptions.py
+++ b/hyperspy/exceptions.py
@@ -190,7 +190,7 @@ class NavigationSizeError(Exception):
             self.navigation_size, self.expected_navigation_size)
 
 
-class NonLinearAccessError(Exception):
+class NonLinearAxisError(Exception):
 
     def __init__(self):
         self.error = f"The called function does not support the use of a non "\

--- a/hyperspy/exceptions.py
+++ b/hyperspy/exceptions.py
@@ -190,6 +190,16 @@ class NavigationSizeError(Exception):
             self.navigation_size, self.expected_navigation_size)
 
 
+class NonLinearAccessError(Exception):
+
+    def __init__(self):
+        self.error = f"The called function does not support the use of a non "\
+                     "linear axis"
+
+    def __str__(self):
+        return repr(self.error)
+
+
 class VisibleDeprecationWarning(UserWarning):
 
     """Visible deprecation warning.

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -1161,9 +1161,12 @@ class Line2DROI(BaseInteractiveROI):
         Notes
         -----
         The destination point is included in the profile, in contrast to
-        standard numpy indexing.
+        standard numpy indexing. Requires linear navigation axes.
 
         """
+        if (not axis[0].is_linear) or (not axis[1].is_linear):
+            raise NonLinearAxisError()        
+        
         import scipy.ndimage as nd
         # Convert points coordinates from axes units to pixels
         p0 = ((src[0] - axes[0].offset) / axes[0].scale,


### PR DESCRIPTION
# Description of the change
Started to add exceptions for functions that so far do not work with non linear axis. So far mainly those in `signal.py`, where I basically checked all functions. Namely this affects (so far):
- axes_manager.convert_units
- signal.derivative
- signal.diff
- signal.rebin
- signal.split
- signal.fft
- signal.ifft
- signal.map

For some it would make sense to add the functionality also for non linear axes (could also be postponed to later PRs), which is also documented as comments in the code, e.g.:
- signal.rebin
- signal.map

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] add tests,
- [ ] ready for review.

