### PR TITLE
hspy read support and more error catches

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -743,7 +743,10 @@ class FunctionalDataAxis(BaseDataAxis):
         kwargs = {}
         for kwarg in self.parameters_list:
             kwargs[kwarg] = getattr(self, kwarg)
-        self.axis = self.function(x=np.arange(self.size), **kwargs)
+        if 'x0' in self.parameters_list:
+            self.axis = self.function(self.x0, **kwargs)
+        else:
+            self.axis = self.function(x=np.arange(self.size), **kwargs)
         # Set not valid values to np.nan
         self.axis[np.logical_not(np.isfinite(self.axis))] = np.nan
         self.size = len(self.axis)
@@ -806,11 +809,17 @@ class FunctionalDataAxis(BaseDataAxis):
         i1 = self._get_positive_index(self._get_index(start))
         i2 = self._get_positive_index(self._get_index(end))
 
-        # Not sure, if we should support unordered values or not...
+        # Create x0 array if it does not exist
+        if not 'x0' in self.parameters_list:
+            self.parameters_list.append('x0')
+            self.x0=np.arange(self.size)
+            self._expression = self._expression.replace('x','x0')
+            self.compile_function()
+        # Functional data axis needs to support reverse order
         if i1 > i2:
-            raise ValueError("The `start` value must be lower than the `end` "
-                             "value.")
-
+            i0 = i1
+            i1 = i2
+            i2 = i0
         self.x0 = self.x0[i1:i2]
         self.update_axis()
 

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -743,10 +743,7 @@ class FunctionalDataAxis(BaseDataAxis):
         kwargs = {}
         for kwarg in self.parameters_list:
             kwargs[kwarg] = getattr(self, kwarg)
-        if 'x0' in self.parameters_list:
-            self.axis = self.function(self.x0, **kwargs)
-        else:
-            self.axis = self.function(x=np.arange(self.size), **kwargs)
+        self.axis = self.function(x=np.arange(self.size), **kwargs)
         # Set not valid values to np.nan
         self.axis[np.logical_not(np.isfinite(self.axis))] = np.nan
         self.size = len(self.axis)
@@ -785,6 +782,7 @@ class FunctionalDataAxis(BaseDataAxis):
         self.__init__(**d, axis=self.axis)
 
     def crop(self, start=None, end=None):
+        
         """Crop the axis in place.
 
         Parameters
@@ -799,29 +797,16 @@ class FunctionalDataAxis(BaseDataAxis):
             the value is taken as the axis index. If type is ``float`` the index
             is calculated using the axis calibration. If `start`/`end` is
             ``None`` the method crops from/to the low/high end of the axis.
+            
+        Note
+        ----
+        Function still needs to be implemented.
         """
-        
-        if start is None:
-            start = 0
-        if end is None:
-            end = self.size
-        # Use `_get_positive_index` to support reserved indexing
-        i1 = self._get_positive_index(self._get_index(start))
-        i2 = self._get_positive_index(self._get_index(end))
 
-        # Create x0 array if it does not exist
-        if not 'x0' in self.parameters_list:
-            self.parameters_list.append('x0')
-            self.x0=np.arange(self.size)
-            self._expression = self._expression.replace('x','x0')
-            self.compile_function()
-        # Functional data axis needs to support reverse order
-        if i1 > i2:
-            i0 = i1
-            i1 = i2
-            i2 = i0
-        self.x0 = self.x0[i1:i2]
-        self.update_axis()
+        raise ValueError('Function still needs to be implemented')
+
+        # TODO
+        pass
 
 
 class LinearDataAxis(FunctionalDataAxis, UnitConversion):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -529,7 +529,7 @@ class BaseDataAxis(t.HasTraits):
             return self.axis[index]
 
     def value2index(self, value, rounding=round):
-        """Return the closest index to the given value if between the limit.
+        """Return the closest index to the given value, if between the limits.
 
         Parameters
         ----------
@@ -782,9 +782,37 @@ class FunctionalDataAxis(BaseDataAxis):
         self.__init__(**d, axis=self.axis)
 
     def crop(self, start=None, end=None):
-        raise ValueError('Function still needs to be implemented')
-        # TODO
-        pass
+        """Crop the axis in place.
+
+        Parameters
+        ----------
+        start : int, float, or None
+            The beginning of the cropping interval. If type is ``int``,
+            the value is taken as the axis index. If type is ``float`` the index
+            is calculated using the axis calibration. If `start`/`end` is
+            ``None`` the method crops from/to the low/high end of the axis.
+        end : int, float, or None
+            The end of the cropping interval. If type is ``int``,
+            the value is taken as the axis index. If type is ``float`` the index
+            is calculated using the axis calibration. If `start`/`end` is
+            ``None`` the method crops from/to the low/high end of the axis.
+        """
+        
+        if start is None:
+            start = 0
+        if end is None:
+            end = self.size
+        # Use `_get_positive_index` to support reserved indexing
+        i1 = self._get_positive_index(self._get_index(start))
+        i2 = self._get_positive_index(self._get_index(end))
+
+        # Not sure, if we should support unordered values or not...
+        if i1 > i2:
+            raise ValueError("The `start` value must be lower than the `end` "
+                             "value.")
+
+        self.x0 = self.x0[i1:i2]
+        self.update_axis()
 
 
 class LinearDataAxis(FunctionalDataAxis, UnitConversion):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1237,10 +1237,10 @@ class AxesManager(t.HasTraits):
 
     @property
     def all_linear(self):
-        if all([axis.is_linear for axis in self._axes]):
-            return 'True'
+        if any([axis.is_linear == False for axis in self._axes]):
+            return False
         else:
-            return 'False'
+            return True
             
 
     def remove(self, axes):

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -1226,6 +1226,14 @@ class AxesManager(t.HasTraits):
             navigation_extent.append(navigation_axis.high_value)
         return tuple(navigation_extent)
 
+    @property
+    def all_linear(self):
+        if all([axis.is_linear for axis in self._axes]):
+            return 'True'
+        else:
+            return 'False'
+            
+
     def remove(self, axes):
         """Remove one or more axes
         """

--- a/hyperspy/exceptions.py
+++ b/hyperspy/exceptions.py
@@ -193,7 +193,7 @@ class NavigationSizeError(Exception):
 class NonLinearAxisError(Exception):
 
     def __init__(self):
-        self.error = ("Non linear axis are not supported.")
+        self.error = ("Non linear axes are not supported.")
 
     def __str__(self):
         return repr(self.error)

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -528,10 +528,10 @@ def save(filename, signal, overwrite=None, **kwds):
             raise IOError('This file format cannot write this data. '
                           'The following formats can: %s' %
                           strlist2enumeration(yes_we_can))
-        if writer.non_linear_axis is not True and nla is not True:
+        if writer.non_linear_axis is False and nla is False:
             yes_we_can = [plugin.format_name for plugin in io_plugins
                           if plugin.non_linear_axis is True]
-            raise IOError('Writing to this format is not supported for non '
+            raise OSError('Writing to this format is not supported for non '
                           'linear axes.'
                           'Use one of the following formats: %s' %
                           strlist2enumeration(yes_we_can))

--- a/hyperspy/io.py
+++ b/hyperspy/io.py
@@ -515,6 +515,7 @@ def save(filename, signal, overwrite=None, **kwds):
         # Check if the writer can write
         sd = signal.axes_manager.signal_dimension
         nd = signal.axes_manager.navigation_dimension
+        nla = signal.axes_manager.all_linear
         if writer.writes is False:
             raise ValueError('Writing to this format is not '
                              'supported, supported file extensions are: %s ' %
@@ -526,6 +527,13 @@ def save(filename, signal, overwrite=None, **kwds):
                           (sd, nd) in plugin.writes]
             raise IOError('This file format cannot write this data. '
                           'The following formats can: %s' %
+                          strlist2enumeration(yes_we_can))
+        if writer.non_linear_axis is not True and nla is not True:
+            yes_we_can = [plugin.format_name for plugin in io_plugins
+                          if plugin.non_linear_axis is True]
+            raise IOError('Writing to this format is not supported for non '
+                          'linear axes.'
+                          'Use one of the following formats: %s' %
                           strlist2enumeration(yes_we_can))
         ensure_directory(filename)
         is_file = os.path.isfile(filename)

--- a/hyperspy/io_plugins/README
+++ b/hyperspy/io_plugins/README
@@ -21,6 +21,8 @@ All the read/write plugins must provide a python file containing:
         writes_images = <Bool>
         writes_spectrum = <Bool>
         writes_spectrum_image = <Bool>
+        # Support for non linear axis
+        non_linear_axis = <Bool>
 
     - A function called file_reader with at least one attribute: filename
 

--- a/hyperspy/io_plugins/README
+++ b/hyperspy/io_plugins/README
@@ -7,7 +7,7 @@ All the read/write plugins must provide a python file containing:
 
         # Plugin characteristics
         # ----------------------
-	format_name = <String>
+	    format_name = <String>
         description = <String>
         full_support = <Bool>	# Whether all the Hyperspy features are supported
         # Recognised file extension

--- a/hyperspy/io_plugins/__init__.py
+++ b/hyperspy/io_plugins/__init__.py
@@ -35,14 +35,12 @@ try:
     io_plugins.append(netcdf)
 except ImportError:
     pass
-    # NetCDF is obsolate and is only provided for users who have
-    # old EELSLab files. Therefore, we silenly ignore if missing.
+    # NetCDF is obsolete and is only provided for users who have
+    # old EELSLab files. Therefore, we silently ignore if missing.
 
 try:
     from hyperspy.io_plugins import hspy
     io_plugins.append(hspy)
-    from hyperspy.io_plugins import emd
-    io_plugins.append(emd)
 except ImportError:
     _logger.warning('The HDF5 IO features are not available. '
                     'It is highly reccomended to install h5py')

--- a/hyperspy/io_plugins/blockfile.py
+++ b/hyperspy/io_plugins/blockfile.py
@@ -40,7 +40,9 @@ file_extensions = ['blo', 'BLO']
 default_extension = 0
 # Writing capabilities:
 writes = [(2, 2), (2, 1), (2, 0)]
+non_linear_axis = False
 magics = [0x0102]
+# ----------------------
 
 
 mapping = {

--- a/hyperspy/io_plugins/bruker.py
+++ b/hyperspy/io_plugins/bruker.py
@@ -56,6 +56,8 @@ reads_spectrum = True
 reads_spectrum_image = True
 # Writing capabilities
 writes = False
+non_linear_axis = False
+# ----------------------
 
 
 _logger = logging.getLogger(__name__)

--- a/hyperspy/io_plugins/dens.py
+++ b/hyperspy/io_plugins/dens.py
@@ -34,6 +34,8 @@ file_extensions = ['dens', 'DENS']
 default_extension = 0
 # Writing capabilities
 writes = False
+non_linear_axis = False
+# ----------------------
 
 
 def _cnv_time(timestr):

--- a/hyperspy/io_plugins/digital_micrograph.py
+++ b/hyperspy/io_plugins/digital_micrograph.py
@@ -46,8 +46,9 @@ full_support = False
 # Recognised file extension
 file_extensions = ('dm3', 'DM3', 'dm4', 'DM4')
 default_extension = 0
-# Writing features
+# Writing capabilities
 writes = False
+non_linear_axis = False
 # ----------------------
 
 

--- a/hyperspy/io_plugins/edax.py
+++ b/hyperspy/io_plugins/edax.py
@@ -48,6 +48,9 @@ file_extensions = ['spd', 'SPD', 'spc', 'SPC']
 default_extension = 0
 # Writing capabilities
 writes = False
+non_linear_axis = False
+# ----------------------
+
 
 spd_extensions = ('spd', 'SPD', 'Spd')
 spc_extensions = ('spc', 'SPC', 'Spc')

--- a/hyperspy/io_plugins/emd.py
+++ b/hyperspy/io_plugins/emd.py
@@ -53,8 +53,9 @@ default_extension = 0
 reads_images = True
 reads_spectrum = True
 reads_spectrum_image = True
-# Writing features
+# Writing capabilities
 writes = True  # Only Berkeley emd
+non_linear_axis = False
 EMD_VERSION = '0.2'
 # ----------------------
 

--- a/hyperspy/io_plugins/fei.py
+++ b/hyperspy/io_plugins/fei.py
@@ -46,6 +46,7 @@ file_extensions = ser_extensions + emi_extensions
 default_extension = 0
 # Writing capabilities
 writes = False
+non_linear_axis = False
 # ----------------------
 
 data_types = {

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -236,8 +236,6 @@ def hdfgroup2signaldict(group, lazy=False):
                     axis[key] = bool(item)
                 else:
                     axis[key] = ensure_unicode(item)
-            if 'x0' in group['axis-%i' % i].keys():
-                axis['x0'] = group['axis-%i/x0' % i][()]
             if 'axis' in group['axis-%i' % i].keys():
                 axis['axis'] = group['axis-%i/axis' % i][()]
         except KeyError:

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -43,7 +43,9 @@ file_extensions = ['hspy', 'hdf5']
 default_extension = 0
 # Writing capabilities
 writes = True
-version = "3.0"
+non_linear_axis = True
+version = "3.1"
+# ----------------------
 
 # -----------------------
 # File format description
@@ -73,6 +75,9 @@ version = "3.0"
 # Experiments instance
 #
 # CHANGES
+#
+# v3.1
+# - add read support for non-linear DataAxis and FunctionalDataAxis
 #
 # v3.0
 # - add Camera and Stage node
@@ -231,6 +236,10 @@ def hdfgroup2signaldict(group, lazy=False):
                     axis[key] = bool(item)
                 else:
                     axis[key] = ensure_unicode(item)
+            if 'x0' in group['axis-%i' % i].keys():
+                axis['x0'] = group['axis-%i/x0' % i][()]
+            if 'axis' in group['axis-%i' % i].keys():
+                axis['axis'] = group['axis-%i/axis' % i][()]
         except KeyError:
             break
     if len(axes) != len(exp['data'].shape):  # broke from the previous loop

--- a/hyperspy/io_plugins/hspy.py
+++ b/hyperspy/io_plugins/hspy.py
@@ -50,34 +50,35 @@ version = "3.1"
 # -----------------------
 # File format description
 # -----------------------
-# The root must contain a group called Experiments
-# The experiments group can contain any number of subgroups
-# Each subgroup is an experiment or signal
-# Each subgroup must contain at least one dataset called data
-# The data is an array of arbitrary dimension
-# In addition a number equal to the number of dimensions of the data
+# The root must contain a group called Experiments.
+# The experiments group can contain any number of subgroups.
+# Each subgroup is an experiment or signal.
+# Each subgroup must contain at least one dataset called data.
+# The data is an array of arbitrary dimension.
+# In addition, a number equal to the number of dimensions of the data
 # dataset + 1 of empty groups called coordinates followed by a number
-# must exists with the following attributes:
+# must exist with the following attributes:
 #    'name'
 #    'offset'
 #    'scale'
 #    'units'
 #    'size'
 #    'index_in_array'
+# Alternatively to 'offset' and 'scale', the coordinate groups may
+# contain an 'axis' vector attribute defining the axis points.
 # The experiment group contains a number of attributes that will be
 # directly assigned as class attributes of the Signal instance. In
 # addition the experiment groups may contain 'original_metadata' and
-# 'metadata'subgroup that will be
-# assigned to the same name attributes of the Signal instance as a
-# Dictionary Browsers
+# 'metadata'-subgroup that will be assigned to the same name attributes 
+# of the Signal instance as a Dictionary Browser.
 # The Experiments group can contain attributes that may be common to all
 # the experiments and that will be accessible as attributes of the
-# Experiments instance
+# Experiments instance.
 #
 # CHANGES
 #
 # v3.1
-# - add read support for non-linear DataAxis and FunctionalDataAxis
+# - add read support for non-linear DataAxis defined by 'axis' vector
 #
 # v3.0
 # - add Camera and Stage node
@@ -88,7 +89,7 @@ version = "3.1"
 # - store quantity for intensity axis
 #
 # v2.1
-# - Store the navigate attribute.
+# - Store the navigate attribute
 # - record_by is stored only for backward compatibility but the axes navigate
 #   attribute takes precendence over record_by for files with version >= 2.1
 # v1.3

--- a/hyperspy/io_plugins/image.py
+++ b/hyperspy/io_plugins/image.py
@@ -31,8 +31,9 @@ full_support = False
 file_extensions = ['png', 'bmp', 'dib', 'gif', 'jpeg', 'jpe', 'jpg',
                    'msp', 'pcx', 'ppm', "pbm", "pgm", 'xbm', 'spi', ]
 default_extension = 0  # png
-# Writing features
+# Writing capabilities
 writes = [(2, 0), ]
+non_linear_axis = False
 # ----------------------
 
 

--- a/hyperspy/io_plugins/mrc.py
+++ b/hyperspy/io_plugins/mrc.py
@@ -41,6 +41,8 @@ file_extensions = ['mrc', 'MRC', 'ALI', 'ali']
 default_extension = 0
 # Writing capabilities
 writes = False
+non_linear_axis = False
+# ----------------------
 
 
 def get_std_dtype_list(endianess='<'):

--- a/hyperspy/io_plugins/mrcz.py
+++ b/hyperspy/io_plugins/mrcz.py
@@ -32,6 +32,8 @@ file_extensions = ['mrc', 'MRC', 'mrcz', 'MRCZ']
 default_extension = 2
 # Writing capabilities:
 writes = True
+non_linear_axis = False
+# ----------------------
 
 
 _POP_FROM_HEADER = ['compressor', 'MRCtype', 'C3', 'dimensions', 'dtype',

--- a/hyperspy/io_plugins/msa.py
+++ b/hyperspy/io_plugins/msa.py
@@ -40,6 +40,7 @@ file_extensions = ('msa', 'ems', 'mas', 'emsa', 'EMS', 'MAS', 'EMSA', 'MSA')
 default_extension = 0
 # Writing capabilities
 writes = [(1, 0), ]
+non_linear_axis = False
 # ----------------------
 
 # For a description of the EMSA/MSA format, incluiding the meaning of the

--- a/hyperspy/io_plugins/netcdf.py
+++ b/hyperspy/io_plugins/netcdf.py
@@ -45,9 +45,9 @@ description = ''
 full_support = True
 file_extensions = ('nc', 'NC')
 default_extension = 0
-# Writing features
+# Writing capabilities
 writes = False
-
+non_linear_axis = False
 # ----------------------
 
 

--- a/hyperspy/io_plugins/protochips.py
+++ b/hyperspy/io_plugins/protochips.py
@@ -39,6 +39,9 @@ reads_spectrum = False
 reads_spectrum_image = False
 # Writing capabilities
 writes = False
+non_linear_axis = False
+# ----------------------
+
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/io_plugins/ripple.py
+++ b/hyperspy/io_plugins/ripple.py
@@ -48,6 +48,7 @@ file_extensions = ['rpl', 'RPL']
 default_extension = 0
 # Writing capabilities
 writes = [(1, 0), (1, 1), (1, 2), (2, 0), (2, 1), ]
+non_linear_axis = False
 # ----------------------
 
 # The format only support the followng data types

--- a/hyperspy/io_plugins/semper_unf.py
+++ b/hyperspy/io_plugins/semper_unf.py
@@ -96,8 +96,9 @@ full_support = True  # Hopefully?
 # Recognised file extension
 file_extensions = ('unf', 'UNF')
 default_extension = 0
-# Writing features
+# Writing capabilities
 writes = [(1, 0), (1, 1), (1, 2), (2, 0), (2, 1)]  # All up to 3D
+non_linear_axis = False
 # ----------------------
 
 

--- a/hyperspy/io_plugins/tiff.py
+++ b/hyperspy/io_plugins/tiff.py
@@ -39,8 +39,9 @@ description = ('Import/Export standard image formats Christoph Gohlke\'s '
 full_support = False
 file_extensions = ['tif', 'tiff']
 default_extension = 0  # tif
-# Writing features
+# Writing capabilities
 writes = [(2, 0), (2, 1)]
+non_linear_axis = False
 # ----------------------
 
 

--- a/hyperspy/roi.py
+++ b/hyperspy/roi.py
@@ -888,6 +888,10 @@ class CircleROI(BaseInteractiveROI):
         else:
             axes = self._parse_axes(axes, signal.axes_manager)
 
+        for axis in axes:
+            if not axis.is_linear:
+                raise NonLinearAxisError()
+
         natax = signal.axes_manager._get_axes_in_natural_order()
         # Slice original data with a circumscribed rectangle
         cx = self.cx + 0.5001 * axes[0].scale
@@ -1169,7 +1173,7 @@ class Line2DROI(BaseInteractiveROI):
         """
         for axis in axes:
             if not axis.is_linear:
-                raise NonLinearAxisError()        
+                raise NonLinearAxisError()
         
         import scipy.ndimage as nd
         # Convert points coordinates from axes units to pixels

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -182,6 +182,19 @@ class TestFunctionalDataAxis:
         assert isinstance(axis, FunctionalDataAxis)
         self._test_initialisation_parameters(axis)
 
+    @pytest.mark.parametrize("use_indices", (True, False))
+    def test_crop(self, use_indices):
+        axis = self.axis
+        print(axis.axis)
+        start, end = 10.1, 10.8
+        if use_indices:
+            start = axis.value2index(start)
+            end = axis.value2index(end)
+        axis.crop(start, end)
+        assert axis.size == 7
+        np.testing.assert_almost_equal(axis.axis[0], 10.1)
+        np.testing.assert_almost_equal(axis.axis[-1], 10.7)
+
 
 class TestReciprocalDataAxis:
 
@@ -204,7 +217,7 @@ class TestReciprocalDataAxis:
     def test_create_axis(self):
         axis = create_axis(**self.axis.get_axis_dictionary())
         assert isinstance(axis, FunctionalDataAxis)
-        self._test_initialisation_parameters(axis)        
+        self._test_initialisation_parameters(axis)
 
 
 class TestLinearDataAxis:

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -182,19 +182,6 @@ class TestFunctionalDataAxis:
         assert isinstance(axis, FunctionalDataAxis)
         self._test_initialisation_parameters(axis)
 
-    @pytest.mark.parametrize("use_indices", (True, False))
-    def test_crop(self, use_indices):
-        axis = self.axis
-        print(axis.axis)
-        start, end = 10.1, 10.8
-        if use_indices:
-            start = axis.value2index(start)
-            end = axis.value2index(end)
-        axis.crop(start, end)
-        assert axis.size == 7
-        np.testing.assert_almost_equal(axis.axis[0], 10.1)
-        np.testing.assert_almost_equal(axis.axis[-1], 10.7)
-
 
 class TestReciprocalDataAxis:
 

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -338,6 +338,7 @@ def test_rgba16():
         "test_rgba16.npy"))
     assert (s.data == data).all()
 
+
 def test_nonlinearaxis():
     axis = DataAxis(axis = 1/np.arange(data.size), navigate = False)
     s = Signal1D(data, axes = (axis.get_axis_dictionary(), ))
@@ -349,23 +350,7 @@ def test_nonlinearaxis():
     assert(s2.axes_manager[0].navigate == False)
     assert(s2.axes_manager[0].size == data.size)
     
-def test_functionalaxis():
-    ax0 = 300 + np.arange(data.size)
-    axis = FunctionalDataAxis(size=data.size, expression='a / x0',  a=1240, 
-                              x0=ax0[::-1], name = 'Energy', units = 'eV')
-    s = Signal1D(data[::-1], axes=(axis.get_axis_dictionary(), ))
-    s.save('tmp.hdf5', overwrite=True)
-    s2 = load('tmp.hdf5')
-    np.testing.assert_array_almost_equal(s.axes_manager[0].axis, 
-                                         s2.axes_manager[0].axis)
-    assert(s2.axes_manager[0].is_linear == False)
-    assert(s2.axes_manager[0].navigate == False)
-    assert(s2.axes_manager[0].size == data.size)
-    assert(s2.axes_manager[0].name == 'Energy')
-    assert(s2.axes_manager[0].units == 'eV')
-    assert(s2.axes_manager[0]._expression == 'a / x0')
-    assert(s2.axes_manager[0].a == 1240)
-    
+   
 class TestLoadingOOMReadOnly:
 
     def setup_method(self, method):

--- a/hyperspy/tests/io/test_hdf5.py
+++ b/hyperspy/tests/io/test_hdf5.py
@@ -339,9 +339,9 @@ def test_rgba16():
     assert (s.data == data).all()
 
 def test_nonlinearaxis():
-    axis = DataAxis(axis = 1/np.arange(data.size), navigate=False)
-    s = Signal1D(data, axes=(axis.get_axis_dictionary(), ))
-    s.save('tmp.hdf5', overwrite=True)
+    axis = DataAxis(axis = 1/np.arange(data.size), navigate = False)
+    s = Signal1D(data, axes = (axis.get_axis_dictionary(), ))
+    s.save('tmp.hdf5', overwrite = True)
     s2 = load('tmp.hdf5')
     np.testing.assert_array_almost_equal(s.axes_manager[0].axis, 
                                          s2.axes_manager[0].axis)

--- a/hyperspy/tests/io/test_io.py
+++ b/hyperspy/tests/io/test_io.py
@@ -23,6 +23,7 @@ import pytest
 from unittest.mock import patch
 
 from hyperspy.signals import Signal1D
+from hyperspy.axes import DataAxis
 
 
 DIRPATH = os.path.dirname(__file__)
@@ -85,3 +86,23 @@ class TestIOOverwriting:
 
     def teardown_method(self, method):
         self._clean_file()
+
+class TestNonLinearAxisCheck:
+
+    def setup_method(self, method):
+        axis = DataAxis(axis = 1/np.arange(10), navigate = False)
+        self.s = Signal1D(np.arange(10), axes=(axis.get_axis_dictionary(), ))
+        # make sure we start from a clean state
+    
+    def test_io_nonlinear(self):
+        assert(self.s.axes_manager[0].is_linear == False)
+        self.s.save('tmp.hspy', overwrite = True)
+        with pytest.raises(OSError):
+            self.s.save('tmp.msa', overwrite = True)
+
+    def teardown_method(self):
+        if os.path.exists('tmp.hspy'):
+            os.remove('tmp.hspy')
+        if os.path.exists('tmp.msa'):
+            os.remove('tmp.msa')
+            


### PR DESCRIPTION
### Description of the change
- Adapted hspy-reader so that non-linear `DataAxis` is correctly read back into a signal object (by checking if a vector `axis` exists in the saved axes object).
- Added `non_linear_axis` to plugin characteristics, and added error message on write for file formats where this property is `False` (so far all but `hspy`)
- Additional catch in `roi.py`

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] Add tests,
- [X] Debug,
- [X] Update docstrings,
- [X] ready for review.