### PR TITLE
Derivative for non-linear axes

### DIFF
--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -498,7 +498,7 @@ class EELSSpectrum_mixin:
                                     window_length=window_length,
                                     differential_order=1)
         else:
-            s = s.diff(-1)
+            s = s.derivative(-1)
         if tol is None:
             tol = np.max(np.abs(s.data).min(axis.index_in_array))
         saxis = s.axes_manager[-1]

--- a/hyperspy/_signals/lazy.py
+++ b/hyperspy/_signals/lazy.py
@@ -313,6 +313,11 @@ class LazySignal(BaseSignal):
         self._make_lazy(rechunk=True)
 
     def diff(self, axis, order=1, out=None, rechunk=True):
+        if not self.axes_manager[axis].is_linear:
+            raise NotImplementedError(
+            "Performing a numerical difference on a non-linear axis "
+            "is not implemented. Consider using `derivative` instead."
+        )
         arr_axis = self.axes_manager[axis].index_in_array
 
         def dask_diff(arr, n, axis):
@@ -348,11 +353,8 @@ class LazySignal(BaseSignal):
                     "The output shape %s does not match  the shape of "
                     "`out` %s" % (new_data.shape, out.data.shape))
         axis2 = s.axes_manager[axis]
-        if not self.axes_manager[axis].is_linear:
-            axis2.axes_manager[axis].axis = self.axes_manager[axis].axis[:-1]
-        else:
-            new_offset = self.axes_manager[axis].offset + (order * axis2.scale / 2)
-            axis2.offset = new_offset
+        new_offset = self.axes_manager[axis].offset + (order * axis2.scale / 2)
+        axis2.offset = new_offset
         s.get_dimensions_from_data()
         if out is None:
             return s

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -300,11 +300,13 @@ class Signal1D(BaseSignal, CommonSignal1D):
         """
         self._check_signal_dimension_equals_one()
         dc = self.data
+        axis = self.axes_manager.signal_axes[0].axis
         if signal_mask is not None:
             dc = dc[..., ~signal_mask]
+            axis = axis[~signal_mask]
         if navigation_mask is not None:
             dc = dc[~navigation_mask, :]
-        der = np.abs(np.diff(dc, 1, -1))
+        der = np.abs(np.gradient(dc, axis, -1))
         n = ((~navigation_mask).sum() if navigation_mask else
              self.axes_manager.navigation_size)
 

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -898,6 +898,10 @@ class Signal1D(BaseSignal, CommonSignal1D):
         More information about the filter in `scipy.signal.savgol_filter`.
         """
         self._check_signal_dimension_equals_one()
+        if not self.axes_manager.signal_axes[0].is_linear():
+            raise NotImplementedError(
+            "This functionality is not implement for signals with non-linear axes. ")
+            "Consider using `smooth_lowess` instead."
         if (polynomial_order is not None and
                 window_length is not None):
             axis = self.axes_manager.signal_axes[0]
@@ -996,6 +1000,10 @@ class Signal1D(BaseSignal, CommonSignal1D):
             If the signal dimension is not 1.
         """
         self._check_signal_dimension_equals_one()
+        if not self.axes_manager.signal_axes[0].is_linear():
+            raise NotImplementedError(
+            "This functionality is not implement for signals with non-linear axes. ")
+            "Consider using `smooth_lowess` instead."
         if smoothing_parameter is None:
             smoother = SmoothingTV(self)
             return smoother.gui(display=display, toolkit=toolkit)
@@ -1025,6 +1033,10 @@ class Signal1D(BaseSignal, CommonSignal1D):
         SignalDimensionError
             If the signal dimension is not 1.
         """
+        if not self.axes_manager.signal_axes[0].is_linear():
+            raise NotImplementedError(
+            "This functionality is not implement for signals with non-linear axes. ")
+            "Consider using `smooth_lowess` instead."
         self._check_signal_dimension_equals_one()
         smoother = ButterworthFilter(self)
         if cutoff_frequency_ratio is not None:

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -898,7 +898,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
         More information about the filter in `scipy.signal.savgol_filter`.
         """
         self._check_signal_dimension_equals_one()
-        if not self.axes_manager.signal_axes[0].is_linear():
+        if not self.axes_manager.signal_axes[0].is_linear:
             raise NotImplementedError(
             "This functionality is not implement for signals with non-linear axes. ")
             "Consider using `smooth_lowess` instead."
@@ -1000,7 +1000,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             If the signal dimension is not 1.
         """
         self._check_signal_dimension_equals_one()
-        if not self.axes_manager.signal_axes[0].is_linear():
+        if not self.axes_manager.signal_axes[0].is_linear:
             raise NotImplementedError(
             "This functionality is not implement for signals with non-linear axes. ")
             "Consider using `smooth_lowess` instead."
@@ -1033,7 +1033,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
         SignalDimensionError
             If the signal dimension is not 1.
         """
-        if not self.axes_manager.signal_axes[0].is_linear():
+        if not self.axes_manager.signal_axes[0].is_linear:
             raise NotImplementedError(
             "This functionality is not implement for signals with non-linear axes. ")
             "Consider using `smooth_lowess` instead."

--- a/hyperspy/_signals/signal1d.py
+++ b/hyperspy/_signals/signal1d.py
@@ -306,7 +306,7 @@ class Signal1D(BaseSignal, CommonSignal1D):
             axis = axis[~signal_mask]
         if navigation_mask is not None:
             dc = dc[~navigation_mask, :]
-        der = np.abs(np.gradient(dc, axis, -1))
+        der = np.abs(np.gradient(dc, axis, axis=-1))
         n = ((~navigation_mask).sum() if navigation_mask else
              self.axes_manager.navigation_size)
 

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -620,8 +620,8 @@ class MVA():
                                      diff_order=diff_order)
             if mask is not None:
                 # The following is a little trick to dilate the mask as
-                # required when operation on the differences. It exploits the
-                # fact that np.diff autimatically "dilates" nans. The trick has
+                # required when operating on differences. It exploits the
+                # fact that np.diff automatically "dilates" nans. The trick has
                 # a memory penalty which should be low compare to the total
                 # memory required for the core application in most cases.
                 mask_diff_axes = (

--- a/hyperspy/learn/mva.py
+++ b/hyperspy/learn/mva.py
@@ -57,7 +57,7 @@ def centering_and_whitening(X):
 
 def get_derivative(signal, diff_axes, diff_order):
     if signal.axes_manager.signal_dimension == 1:
-        signal = signal.diff(order=diff_order, axis=-1)
+        signal = signal.derivative(order=diff_order, axis=-1)
     else:
         # n-d signal case.
         # Compute the differences for each signal axis, unfold the

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3308,6 +3308,11 @@ class BaseSignal(FancySlicing,
         >>> s.diff(-1).data.shape
         (64,64,1023)
         """
+        if not self.axes_manager[axis].is_linear:
+            raise NotImplementedError(
+            "Performing a numerical difference on a non-linear axis "
+            "is not implemented. Consider using `derivative` instead."
+        )
         s = out or self._deepcopy_with_new_data(None)
         data = np.diff(self.data, n=order,
                        axis=self.axes_manager[axis].index_in_array)
@@ -3316,14 +3321,8 @@ class BaseSignal(FancySlicing,
         else:
             s.data = data
         axis2 = s.axes_manager[axis]
-        if not self.axes_manager[axis].is_linear:
-            raise NotImplementedError(
-            "Performing a numerical difference on a non-linear axis "
-            "is not implemented. Consider using `derivative` instead."
-        )
-        else:
-            new_offset = self.axes_manager[axis].offset + (order * axis2.scale / 2)
-            axis2.offset = new_offset
+        new_offset = self.axes_manager[axis].offset + (order * axis2.scale / 2)
+        axis2.offset = new_offset
         s.get_dimensions_from_data()
         if out is None:
             return s
@@ -3331,7 +3330,7 @@ class BaseSignal(FancySlicing,
             out.events.data_changed.trigger(obj=out)
     diff.__doc__ %= (ONE_AXIS_PARAMETER, OUT_ARG, RECHUNK_ARG)
 
-    def derivative(self, axis, order=1, out=None, rechunk=True, legacy=True, **kwargs):
+    def derivative(self, axis, order=1, out=None, rechunk=True, legacy=False, **kwargs):
         r"""Calculate the numerical derivative along the given axis,
         with respect to the calibrated units of that axis.
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3947,20 +3947,23 @@ class BaseSignal(FancySlicing,
                 ndkwargs += ((key, value),)
 
         # TODO: Consider support for non linear signal axis
-        if any([not ax.is_linear for ax in self.axes_manager.signal_axes]): 
-            raise NonLinearAxisError()
-        # Check if the signal axes have inhomogeneous scales and/or units and
-        # display in warning if yes.
-        scale = set()
-        units = set()
-        for i in range(len(self.axes_manager.signal_axes)):
-            scale.add(self.axes_manager.signal_axes[i].scale)
-            units.add(self.axes_manager.signal_axes[i].units)
-        if len(units) != 1 or len(scale) != 1:
+        if any([not ax.is_linear for ax in self.axes_manager.signal_axes]):
             _logger.warning(
-                "The function you applied does not take into "
-                "account the difference of units and of scales in-between"
-                " axes.")
+                "At least one axis of the signal is non-linear. Can your "
+                "`function` operate on non-linear axes?")
+        else:
+            # Check if the signal axes have inhomogeneous scales and/or units and
+            # display in warning if yes.
+            scale = set()
+            units = set()
+            for i in range(len(self.axes_manager.signal_axes)):
+                scale.add(self.axes_manager.signal_axes[i].scale)
+                units.add(self.axes_manager.signal_axes[i].units)
+            if len(units) != 1 or len(scale) != 1:
+                _logger.warning(
+                    "The function you applied does not take into "
+                    "account the difference of units and of scales in-between"
+                    " axes.")
         # If the function has an axis argument and the signal dimension is 1,
         # we suppose that it can operate on the full array and we don't
         # iterate over the coordinates.

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3319,7 +3319,7 @@ class BaseSignal(FancySlicing,
         if not self.axes_manager[axis].is_linear:
             raise NotImplementedError(
             "Performing a numerical difference on a non-linear axis "
-            "is not implemented. Please use `derivative` instead."
+            "is not implemented. Consider using `derivative` instead."
         )
         else:
             new_offset = self.axes_manager[axis].offset + (order * axis2.scale / 2)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -3317,8 +3317,11 @@ class BaseSignal(FancySlicing,
             s.data = data
         axis2 = s.axes_manager[axis]
         if not self.axes_manager[axis].is_linear:
-            axis2.axes_manager[axis].axis = self.axes_manager[axis].axis[:-1]
-        else: 
+            raise NotImplementedError(
+            "Performing a numerical difference on a non-linear axis "
+            "is not implemented. Please use `derivative` instead."
+        )
+        else:
             new_offset = self.axes_manager[axis].offset + (order * axis2.scale / 2)
             axis2.offset = new_offset
         s.get_dimensions_from_data()

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1242,6 +1242,7 @@ class SpikesRemoval(SpanSelectorInSignal1D):
                                       navigation_mask=self.navigation_mask)
 
     def detect_spike(self):
+        print("detect spike")
         axis = self.signal.axes_manager.signal_axes[-1].axis
         derivative = np.gradient(self.signal(), axis)
         if self.signal_mask is not None:

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1239,13 +1239,14 @@ class SpikesRemoval(SpanSelectorInSignal1D):
                                       navigation_mask=self.navigation_mask)
 
     def detect_spike(self):
-        derivative = np.diff(self.signal())
+        axis = self.signal.axes_manager.signal_axes[-1].axis
+        derivative = np.gradient(self.signal(), axis)
         if self.signal_mask is not None:
-            derivative[self.signal_mask[:-1]] = 0
+            derivative[self.signal_mask] = 0
         if self.argmax is not None:
             left, right = self.get_interpolation_range()
             self._temp_mask[left:right] = True
-            derivative[self._temp_mask[:-1]] = 0
+            derivative[self._temp_mask] = 0
         if abs(derivative.max()) >= self.threshold:
             self.argmax = derivative.argmax()
             self.derivmax = abs(derivative.max())

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -1242,14 +1242,15 @@ class SpikesRemoval(SpanSelectorInSignal1D):
                                       navigation_mask=self.navigation_mask)
 
     def detect_spike(self):
-        print("detect spike")
         axis = self.signal.axes_manager.signal_axes[-1].axis
         derivative = np.gradient(self.signal(), axis)
         if self.signal_mask is not None:
             derivative[self.signal_mask] = 0
         if self.argmax is not None:
             left, right = self.get_interpolation_range()
-            self._temp_mask[left:right] = True
+            # Don't search for spikes in the are where one has
+            # been found next time `find` is called.
+            self._temp_mask[left:right + 1] = True
             derivative[self._temp_mask] = 0
         if abs(derivative.max()) >= self.threshold:
             self.argmax = derivative.argmax()

--- a/hyperspy/signal_tools.py
+++ b/hyperspy/signal_tools.py
@@ -355,8 +355,11 @@ class Smoothing(t.HasTraits):
             pass
 
     def diff_model2plot(self, axes_manager=None):
-        smoothed = np.diff(self.model2plot(axes_manager),
-                           self.differential_order)
+        n = self.differential_order
+        smoothed = self.model2plot(axes_manager)
+        while n:
+            smoothed = np.gradient(smoothed, self.axis)
+            n -= 1
         return smoothed
 
     def close(self):

--- a/hyperspy/tests/mva/test_bss.py
+++ b/hyperspy/tests/mva/test_bss.py
@@ -146,26 +146,33 @@ class TestBSS2D:
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_diff_axes_string_with_mask(self):
         mask = self.s._get_signal_signal(dtype="bool")
+        mask.data[:] = False
         mask.unfold()
         mask.isig[5] = True
         mask.fold()
         self.s.learning_results.factors[5, :] = np.nan
         factors = self.s.get_decomposition_factors().inav[:3]
         self.s.blind_source_separation(
-            3, diff_order=0, fun="exp", on_loadings=False,
-            factors=factors.diff(axis="x", order=1),
-            mask=mask.diff(axis="x", order=1))
-        matrix = self.s.learning_results.unmixing_matrix.copy()
-        self.s.blind_source_separation(
             3, diff_order=1, fun="exp", on_loadings=False,
             diff_axes=["x"], mask=mask
         )
+        matrix = self.s.learning_results.unmixing_matrix.copy()
+        mask.change_dtype("float")
+        mask.data[mask.data == 1] = np.nan
+        mask.fold()
+        mask = mask.derivative(axis="x")
+        mask.data[np.isnan(mask.data)] = 1
+        mask.change_dtype("bool")
+        self.s.blind_source_separation(
+            3, diff_order=0, fun="exp", on_loadings=False,
+            factors=factors.derivative(axis="x", order=1),
+            mask=mask)
         assert np.allclose(matrix, self.s.learning_results.unmixing_matrix,
                            atol=1e-6)
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_diff_axes_string_without_mask(self):
-        factors = self.s.get_decomposition_factors().inav[:3].diff(
+        factors = self.s.get_decomposition_factors().inav[:3].derivative(
             axis="x", order=1)
         self.s.blind_source_separation(
             3, diff_order=0, fun="exp", on_loadings=False, factors=factors)
@@ -179,7 +186,7 @@ class TestBSS2D:
 
     @pytest.mark.skipif(not sklearn_installed, reason="sklearn not installed")
     def test_diff_axes_without_mask(self):
-        factors = self.s.get_decomposition_factors().inav[:3].diff(
+        factors = self.s.get_decomposition_factors().inav[:3].derivative(
             axis="y", order=1)
         self.s.blind_source_separation(
             3, diff_order=0, fun="exp", on_loadings=False, factors=factors)

--- a/hyperspy/tests/signal/test_tools.py
+++ b/hyperspy/tests/signal/test_tools.py
@@ -754,8 +754,8 @@ class TestDerivative:
 
     def test_derivative_data(self):
         der = self.s.derivative(axis=0, order=4)
-        nt.assert_allclose(der.data, np.sin(
-            der.axes_manager[0].axis), atol=1e-2)
+        nt.assert_allclose(der.data[4:-4], np.sin(
+            der.axes_manager[0].axis[4:-4]), atol=1e-2)
 
 
 @lazifyTestClass
@@ -1118,11 +1118,10 @@ def test_lazy_reduce_rechunk():
 
 def test_lazy_diff_rechunk():
     s = signals.Signal1D(da.ones((10, 100), chunks=(1, 2))).as_lazy()
-    for rm in (s.derivative, s.diff):
-        # The data has been rechunked
-        assert rm(axis=-1).data.chunks == ((10,), (99,))
-        assert rm(axis=-1, rechunk=False).data.chunks == ((1,) *
-                                                          10, (1,) * 99)  # The data has not been rechunked
+    # The data has been rechunked
+    assert s.diff(axis=-1).data.chunks == ((10,), (99,))
+    assert s.diff(axis=-1, rechunk=False).data.chunks == ((1,) *
+                                                      10, (1,) * 99)  # The data has not been rechunked
 
 
 def test_spikes_removal_tool():


### PR DESCRIPTION
This also:

* fixes BSS by using derivative instead of diff
* raises NotImplementedError when calling ``diff``, ``smooth_tv`` and ``smooth_savitzky_golay`` on signals with non-linear axes
* enables ``map`` for non-linear axes