### PR TITLE
Redefined FunctionalDataAxis with offset/scale.

### DIFF
--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -54,8 +54,7 @@ class ndindex_nat(np.ndindex):
 
 
 def generate_linear_axis(offset, scale, size, offset_index=0):
-    """Creates a linear axis vector given the offset, scale and number of
-    channels.
+    """Creates a linear axis given the offset, scale and number of channels
 
     Alternatively, the offset_index of the offset channel can be specified.
 
@@ -530,7 +529,7 @@ class BaseDataAxis(t.HasTraits):
             return self.axis[index]
 
     def value2index(self, value, rounding=round):
-        """Return the closest index to the given value if between the limit.
+        """Return the closest index to the given value, if between the limits.
 
         Parameters
         ----------
@@ -713,10 +712,14 @@ class FunctionalDataAxis(BaseDataAxis):
                  units=t.Undefined,
                  navigate=t.Undefined,
                  size=1.,
+                 scale=1.,
+                 offset=1.,
                  expression=None,
                  **parameters):
         super().__init__(index_in_array, name, units, navigate)
         self.size = size
+        self.scale = scale
+        self.offset = offset
 
         self.parameters_list = [key for key in parameters.keys()]
         self._expression = expression
@@ -744,7 +747,8 @@ class FunctionalDataAxis(BaseDataAxis):
         kwargs = {}
         for kwarg in self.parameters_list:
             kwargs[kwarg] = getattr(self, kwarg)
-        self.axis = self.function(x=np.arange(self.size), **kwargs)
+        x0 = self.scale * np.arange(self.size) + self.offset
+        self.axis = self.function(x=x0, **kwargs)
         # Set not valid values to np.nan
         self.axis[np.logical_not(np.isfinite(self.axis))] = np.nan
         self.size = len(self.axis)
@@ -772,7 +776,9 @@ class FunctionalDataAxis(BaseDataAxis):
     def get_axis_dictionary(self):
         d = super().get_axis_dictionary()
         d['expression'] = self._expression
-        d['size'] = self.size
+        d.update({'size': self.size,
+                  'scale': self.scale,
+                  'offset': self.offset})
         for kwarg in self.parameters_list:
             d[kwarg] = getattr(self, kwarg)
         return d
@@ -783,9 +789,45 @@ class FunctionalDataAxis(BaseDataAxis):
         self.__init__(**d, axis=self.axis)
 
     def crop(self, start=None, end=None):
-        raise ValueError('Function still needs to be implemented')
-        # TODO
-        pass
+        
+        """Crop the axis in place.
+
+        Parameters
+        ----------
+        start : int, float, or None
+            The beginning of the cropping interval. If type is ``int``,
+            the value is taken as the axis index. If type is ``float`` the index
+            is calculated using the axis calibration. If `start`/`end` is
+            ``None`` the method crops from/to the low/high end of the axis.
+        end : int, float, or None
+            The end of the cropping interval. If type is ``int``,
+            the value is taken as the axis index. If type is ``float`` the index
+            is calculated using the axis calibration. If `start`/`end` is
+            ``None`` the method crops from/to the low/high end of the axis.
+            
+        Note
+        ----
+        When cropping an axis with descending axis values based on the axis
+        calibration, the `start`/`end` tuple also has to be in descending
+        order.
+        """
+
+        if start is None:
+            start = 0
+        if end is None:
+            end = self.size
+
+        # Use `_get_positive_index` to support reserved indexing
+        i1 = self._get_positive_index(self._get_index(start))
+        i2 = self._get_positive_index(self._get_index(end))
+
+        x0 = self.scale * np.arange(self.size) + self.offset
+
+        self.offset = x0[i1]
+        self.size = i2 - i1
+        self.update_axis()
+
+    crop.__doc__ = DataAxis.crop.__doc__
 
 
 class LinearDataAxis(FunctionalDataAxis, UnitConversion):
@@ -800,7 +842,7 @@ class LinearDataAxis(FunctionalDataAxis, UnitConversion):
                  size=1.,
                  scale=1.,
                  offset=0.):
-        self.expression = "scale * x + offset"
+        self.expression = "x"
         super().__init__(index_in_array, name, units, navigate, size=size,
                          expression=self.expression, scale=scale,
                          offset=offset)
@@ -1198,6 +1240,14 @@ class AxesManager(t.HasTraits):
             navigation_extent.append(navigation_axis.low_value)
             navigation_extent.append(navigation_axis.high_value)
         return tuple(navigation_extent)
+
+    @property
+    def all_linear(self):
+        if any([axis.is_linear == False for axis in self._axes]):
+            return False
+        else:
+            return True
+            
 
     def remove(self, axes):
         """Remove one or more axes

--- a/hyperspy/axes.py
+++ b/hyperspy/axes.py
@@ -87,7 +87,7 @@ def create_axis(**kwargs):
 
     Parameters
     ----------
-    axis : iteratable of values (list, tuple or 1D numpy array) (optional)
+    axis : iterable of values (list, tuple or 1D numpy array) (optional)
     expression : Component function in SymPy text expression format (str) (optional)
     offset : float (optional)
     scale : float (optional)
@@ -628,7 +628,7 @@ class DataAxis(BaseDataAxis):
         self.update_axis()
 
     def update_axis(self):
-        """Set the value of a axis. The axis value needs to be ordered.
+        """Set the value of a axis. The axis values need to be ordered.
 
         Parameters
         ----------
@@ -1013,9 +1013,9 @@ class AxesManager(t.HasTraits):
     It can only be indexed and sliced to access the DataAxis objects that it
     contains. Standard indexing and slicing follows the "natural order" as in
     Signal, i.e. [nX, nY, ...,sX, sY,...] where `n` indicates a navigation axis
-    and `s` a signal axis. In addition AxesManager support indexing using
-    complex numbers a + bj, where b can be one of 0, 1, 2 and 3 and a a valid
-    index. If b is 3 AxesManager is indexed using the order of the axes in the
+    and `s` a signal axis. In addition, AxesManager supports indexing using
+    complex numbers a + bj, where b can be one of 0, 1, 2 and 3 and a valid
+    index. If b is 3, AxesManager is indexed using the order of the axes in the
     array. If b is 1(2), indexes only the navigation(signal) axes in the
     natural order. In addition AxesManager supports subscription using
     axis name.
@@ -1024,12 +1024,12 @@ class AxesManager(t.HasTraits):
     ----------
 
     coordinates : tuple
-        Get and set the current coordinates if the navigation dimension
-        is not 0. If the navigation dimension is 0 it raises
+        Get and set the current coordinates, if the navigation dimension
+        is not 0. If the navigation dimension is 0, it raises
         AttributeError when attempting to set its value.
     indices : tuple
-        Get and set the current indices if the navigation dimension
-        is not 0. If the navigation dimension is 0 it raises
+        Get and set the current indices, if the navigation dimension
+        is not 0. If the navigation dimension is 0, it raises
         AttributeError when attempting to set its value.
     signal_axes, navigation_axes : list
         Contain the corresponding DataAxis objects
@@ -1290,12 +1290,12 @@ class AxesManager(t.HasTraits):
         return tuple(cslice)
 
     def create_axes(self, axes_list):
-        """Given a list of dictionaries defining the axes properties
+        """Given a list of dictionaries defining the axes properties,
         create the DataAxis instances and add them to the AxesManager.
 
         The index of the axis in the array and in the `_axes` lists
         can be defined by the index_in_array keyword if given
-        for all axes. Otherwise it is defined by their index in the
+        for all axes. Otherwise, it is defined by their index in the
         list.
 
         See also

--- a/hyperspy/tests/axes/test_data_axis.py
+++ b/hyperspy/tests/axes/test_data_axis.py
@@ -166,7 +166,7 @@ class TestFunctionalDataAxis:
     def setup_method(self, method):
         expression = "a * x + b"
         self.axis = FunctionalDataAxis(size=10, expression=expression,
-                                       a=0.1, b=10)
+                                       a=0.1, b=10, offset=0)
 
     def _test_initialisation_parameters(self, axis):
         assert axis.a == 0.1
@@ -182,13 +182,26 @@ class TestFunctionalDataAxis:
         assert isinstance(axis, FunctionalDataAxis)
         self._test_initialisation_parameters(axis)
 
+    @pytest.mark.parametrize("use_indices", (True, False))
+    def test_crop(self, use_indices):
+        axis = self.axis
+        print(axis.axis)
+        start, end = 10.1, 10.8
+        if use_indices:
+            start = axis.value2index(start)
+            end = axis.value2index(end)
+        axis.crop(start, end)
+        assert axis.size == 7
+        np.testing.assert_almost_equal(axis.axis[0], 10.1)
+        np.testing.assert_almost_equal(axis.axis[-1], 10.7)
+
 
 class TestReciprocalDataAxis:
 
     def setup_method(self, method):
         expression = "a / (x + 1) + b"
         self.axis = FunctionalDataAxis(size=10, expression=expression,
-                                       a=0.1, b=10)
+                                       a=0.1, b=10, offset=0)
 
     def _test_initialisation_parameters(self, axis):
         assert axis.a == 0.1
@@ -205,6 +218,19 @@ class TestReciprocalDataAxis:
         axis = create_axis(**self.axis.get_axis_dictionary())
         assert isinstance(axis, FunctionalDataAxis)
         self._test_initialisation_parameters(axis)        
+
+    @pytest.mark.parametrize("use_indices", (True, False))
+    def test_crop(self, use_indices):
+        axis = self.axis
+        print(axis.axis)
+        start, end = 10.05, 10.02
+        if use_indices:
+            start = axis.value2index(start)
+            end = axis.value2index(end)
+        axis.crop(start, end)
+        assert axis.size == 3
+        np.testing.assert_almost_equal(axis.axis[0], 10.05)
+        np.testing.assert_almost_equal(axis.axis[-1], 10.025)
 
 
 class TestLinearDataAxis:


### PR DESCRIPTION
### Description of the change
Based on the discussion with @francisco-dlp in #11, I added `offset` and `scale` attributes to the FunctionalDataAxis. 
- The x-vector is calculated as `x*scale + offset`. Thus, the definition of the derived LinearDataAxis is reduced to `expression = x`.
- The default is `offset=1` for FunctionalDataAxis, to avoid divide by zero in the case of a reciprocal expression (`offset=0` remains the default for LinearDataAxis)
- Added cropping for functional data axis compatible with reciprocal data axes
- Updated tests and added tests for cropping

### Progress of the PR
- [X] Change implemented,
- [X] update docstring,
- [ ] update user guide,
- [X] add tests,
- [X] ready for review.