### PR TITLE
mention reader attribute

### DIFF
--- a/doc/user_guide/getting_started.rst
+++ b/doc/user_guide/getting_started.rst
@@ -164,7 +164,14 @@ Once HyperSpy is running, to load from a supported file format (see
 
 .. code-block:: python
 
-    >>> s = hs.load("filename")
+    >>> s = hs.load("filename.ext")
+
+The used IO-plugin will be inferred from the file extension. If you want to force
+the use of a specific IO-plugin, you can provide the ``reader`` attribute:
+
+.. code-block:: python
+
+    >>> s = hs.load("spam.ham", reader="hspy")
 
 .. note::
 


### PR DESCRIPTION
Similarly, before forgetting about it, I propose a brief mention of the reader attribute and that otherwise the io plugin is chosen by file extension.