### PR TITLE
Update holospy references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -940,7 +940,8 @@ NEW
   artificial data, for use in things like docstrings or for people to test
   HyperSpy functionalities. See :ref:`example-data-label`.
 * New :meth:`~.signal.BaseSignal.fft` and :meth:`~.signal.BaseSignal.ifft` signal methods. See :ref:`signal.fft`.
-* New :meth:`~._signals.hologram_image.HologramImage.statistics` method to compute useful hologram parameters. See :ref:`holography.stats-label`.
+* New :external+holospy:meth:`holospy._signals.hologram_image.HologramImage.statistics` method to compute useful
+  hologram parameters. See :external+holospy::ref:`holography.stats-label`.
 * Automatic axes units conversion and better units handling using `pint <https://pint.readthedocs.io/en/latest/>`__.
   See :ref:`quantity_and_converting_units`.
 * New :class:`~.roi.Line2DROI` :meth:`~.roi.Line2DROI.angle` method. See :ref:`roi-label` for details.
@@ -1123,7 +1124,7 @@ NEW
 * Parallel :py:meth:`~.signal.BaseSignal.map` and all the functions that use
   it internally (a good fraction of HyperSpy's functionaly). See
   :ref:`map-label`.
-* :ref:`electron-holography-label` reconstruction.
+* :external+holospy:ref:`electron-holography-label` reconstruction.
 * Support for reading :external+rsciio:ref:`edax-format` files.
 * New signal methods :py:meth:`~.signal.BaseSignal.indexmin` and
   :py:meth:`~.signal.BaseSignal.valuemin`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -298,6 +298,7 @@ towncrier_draft_working_directory = ".."
 intersphinx_mapping = {
     'cupy': ('https://docs.cupy.dev/en/stable', None),
     'dask': ('https://docs.dask.org/en/latest', None),
+    #'holospy': ('https://hyperspy.org/holospy/', None),
     'h5py': ('https://docs.h5py.org/en/stable', None),
     'IPython': ('https://ipython.readthedocs.io/en/stable', None),
     'matplotlib': ('https://matplotlib.org', None),

--- a/doc/user_guide/signal/complex_datatype.rst
+++ b/doc/user_guide/signal/complex_datatype.rst
@@ -72,8 +72,9 @@ display of the plot respectively. The last one is especially useful in order to
 zoom into specific regions of the plot or to limit the plot in case of noisy
 data points.
 
-An example of calculation of Aragand diagram is :ref:`shown for electron
-holography data <holo.argand-example>`.
+An example of calculating an Aragand diagram is shown in the 
+:external+holospy:ref:`HoloSpy user guide<holo.argand-example>` for electron
+holography data.
 
 Add a linear phase ramp
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Update references in the user guide and changelog to HoloSpy documentation using intersphinx (to be activated in `conf.py` once documentation is available)
